### PR TITLE
[Ad-hoc]: Fix docker-sonic-mgmt build error in sonic-buildimage

### DIFF
--- a/pypkg/__init__.py
+++ b/pypkg/__init__.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))


### PR DESCRIPTION
The original path of pypkg has been used by docker-sonic-mgmt.