### PR TITLE
[build 202311]Update pool sonicbld to sonic-ububtu-1c since it's deprecated

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -10,7 +10,7 @@ parameters:
 - name: pool
   type: string
   values:
-  - sonicbld
+  - sonicbld-1es
   - sonicbld-armhf
   - sonicbld-arm64
   - default

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      pool: sonicbld
+      pool: sonicbld-1es
       sonic_slave: sonic-slave-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
       artifact_name: sonic-dash-api


### PR DESCRIPTION
'sonicbld' agent pool has been deprecated so all the build failed:

![image](https://github.com/sonic-net/sonic-dash-api/assets/4735332/26c98992-a31a-4f17-8927-fed67a08c9cd)

![image](https://github.com/sonic-net/sonic-dash-api/assets/4735332/25c09046-23bd-45e1-a0be-72be2552e695)

The new agent pool is 'sonic-ubuntu-1c'