### PR TITLE
Fix RouteRule action_type field

### DIFF
--- a/misc/tests/utils_unittest.cpp
+++ b/misc/tests/utils_unittest.cpp
@@ -101,18 +101,18 @@ TEST(Utils, CInterface)
 
     const std::string json_str1 = 
     "{\n"
-    " \"action_type\": \"ROUTING_TYPE_UNSPECIFIED\",\n"
-    " \"routing_type\": \"ROUTING_TYPE_VNET\",\n"
+    " \"action_type\": \"ACTION_TYPE_DECAP\",\n"
+    " \"priority\": 2,\n"
     " \"vnet\": \"Vnet2\"\n"
     "}\n";
 
     char binary[256] = {0};
     size_t binary_size = 0;
-    EXPECT_NO_THROW(binary_size = JsonStringToPbBinary("DASH_ROUTE_TABLE", json_str1.c_str(), binary, sizeof(binary)));
+    EXPECT_NO_THROW(binary_size = JsonStringToPbBinary("DASH_ROUTE_RULE_TABLE", json_str1.c_str(), binary, sizeof(binary)));
     EXPECT_GT(binary_size, 0);
 
     char json[256] = {0};
-    EXPECT_NO_THROW(PbBinaryToJsonString("DASH_ROUTE_TABLE", binary, binary_size, json, sizeof(json)));
+    EXPECT_NO_THROW(PbBinaryToJsonString("DASH_ROUTE_RULE_TABLE", binary, binary_size, json, sizeof(json)));
     EXPECT_EQ(string(json), json_str1);
 
     const std::string json_str2 =

--- a/proto/route_rule.proto
+++ b/proto/route_rule.proto
@@ -6,7 +6,7 @@ import "route_type.proto";
 
 message RouteRule {
     // reference to routing type, action can be decap or drop
-    route_type.RoutingType action_type = 1 [deprecated = true]; // renamed as routing_type
+    route_type.ActionType action_type = 1;
     // priority of the rule, lower the value, higher the priority
     uint32 priority = 2;
     // Optional
@@ -24,11 +24,10 @@ message RouteRule {
     // Optional
     // optional region_id which the vni/prefix belongs to as a string for any vendor optimizations
     optional string region = 7;
-    route_type.RoutingType routing_type = 8;
     // Optional
     // Metering class aggregate bits
-    optional uint32 metering_class_or = 9;
-    optional uint32 metering_class_and = 10;
+    optional uint32 metering_class_or = 8;
+    optional uint32 metering_class_and = 9;
 }
 
 // ENI Inbound route table with VNI and optional SRC PA prefix


### PR DESCRIPTION
- The `action_type` field in the RouteRule message is currently defined as a `route_type.RoutingType` value (e.g. privatelink, servicetunnel, etc.). However, based on the [DASH HLD](https://github.com/sonic-net/SONiC/blob/master/doc/dash/dash-sonic-hld.md#3210-route-rule-table---inbound) this field needs to contain `route_type.ActionType` values (e.g. decap, maprouting, etc.)
- Change the `action_type` field to `route_type.ActionType` value and update related tests