### PR TITLE
[ENI] Add member group_id

### DIFF
--- a/proto/eni.proto
+++ b/proto/eni.proto
@@ -34,6 +34,13 @@ message Eni {
     // IPv6 meter policy ID
     optional string v6_meter_policy_id = 10;
     optional bool disable_fast_path_icmp_flow_redirection = 11;
+    // Optional
+    // Route Group ID
+    // SAI api set_eni_attribute is not done in dash sai lib for bmv2, then
+    // EniRoute is not work for dash pipeline bmv2. Current quick fix is to
+    // specify route_group_id in creating ENI. It helps dash test cases in
+    // sonic-mgmt be passed.
+    optional string group_id = 12;
 }
 
 message EniKey {


### PR DESCRIPTION
SAI api `set_eni_attribute` is not done in dash sai lib for dash pipeline bmv2, then DASH orch will fail to process EniRoute message, as to bind one route group to ENI. Current quick fix is to specify route_group_id in creating ENI. It helps dash test cases  be passed in sonic-mgmt.
