### PR TITLE
Make outbound_direction_lookup optional

### DIFF
--- a/proto/appliance.proto
+++ b/proto/appliance.proto
@@ -12,7 +12,7 @@ message Appliance {
     // region where this appliance is located
     uint32 local_region_id = 3;
     // outbound direction lookup
-    string outbound_direction_lookup = 4;
+    optional string outbound_direction_lookup = 4;
 }
 
 message ApplianceKey {


### PR DESCRIPTION
Per https://github.com/sonic-net/SONiC/pull/1911, this an optional field.