### PR TITLE
Add outbound port map proto definitions

### DIFF
--- a/misc/tests/utils_unittest.cpp
+++ b/misc/tests/utils_unittest.cpp
@@ -47,6 +47,8 @@ TEST(Utils, ValidUrlConversion)
         {"sonic/dash.ha_scope_config.HaScopeConfig", "DASH_HA_SCOPE_CONFIG_TABLE"},
         {"sonic/dash.ha_set_state.HaSetState", "DASH_HA_SET_STATE_TABLE"},
         {"sonic/dash.ha_scope_state.HaScopeState", "DASH_HA_SCOPE_STATE_TABLE"},
+        {"sonic/dash.outbound_port_map.OutboundPortMap", "DASH_OUTBOUND_PORT_MAP_TABLE"},
+        {"sonic/dash.outbound_port_map_range.OutboundPortMapRange", "DASH_OUTBOUND_PORT_MAP_RANGE_TABLE"}
     };
     set<string> ignore_files = {
         "types.proto"

--- a/proto/outbound_port_map.proto
+++ b/proto/outbound_port_map.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package dash.outbound_port_map;
+
+import "types.proto";
+
+// Key = DASH_OUTBOUND_PORT_MAP:{map_id}
+message OutboundPortMap {
+    // No real info needed here since this is just a parent to one or more OUTBOUND_PORT_MAP_RANGE entries
+    optional string guid = 1;
+}

--- a/proto/outbound_port_map_range.proto
+++ b/proto/outbound_port_map_range.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package dash.outbound_port_map_range;
+import "types.proto";
+
+enum PortMapRangeAction {
+    ACTION_UNSPECIFIED = 0;
+    ACTION_SKIP_MAPPING = 1;
+    ACTION_MAP_PRIVATE_LINK_SERVICE = 2;
+}
+
+// Key = DASH_OUTBOUND_PORT_MAP_RANGE:{map_id}:{start port}-{end port}
+message OutboundPortMapRange {
+    PortMapRangeAction action = 1;
+    types.IpAddress backend_ip = 2;
+    uint32 backend_port_base = 3;
+}

--- a/proto/vnet_mapping.proto
+++ b/proto/vnet_mapping.proto
@@ -38,6 +38,8 @@ message VnetMapping {
     optional types.IpPrefix overlay_dip_prefix = 14;
     optional string tunnel = 15;
     route_type.RoutingType routing_type = 16;
+    // Specifies port map from DASH_OUTBOUND_PORT_MAP_TABLE to use for PL redirect map
+    optional string port_map = 17;
 }
 
 // CA-PA mapping table for Vnet


### PR DESCRIPTION
As per https://github.com/sonic-net/SONiC/pull/2015

- Add `port_map` field to `VnetMessage`
- Add `OutboundPortMap` and `OutboundPortMapRange` message types