### PR TITLE
Use ValueOrRange for trusted_vni fields

### DIFF
--- a/misc/tests/test_utils.py
+++ b/misc/tests/test_utils.py
@@ -47,7 +47,6 @@ def test_dash_api_utils():
  },
  "vm_vni": 4321,
  "local_region_id": 100,
- "trusted_vnis": [],
  "outbound_direction_lookup": "dst_mac"
 }
     '''

--- a/misc/tests/utils_unittest.cpp
+++ b/misc/tests/utils_unittest.cpp
@@ -127,7 +127,8 @@ TEST(Utils, CInterface)
     "  \"ipv4\": 16777482\n"
     " },\n"
     " \"vm_vni\": 4321,\n"
-    " \"local_region_id\": 100\n"
+    " \"local_region_id\": 100,\n"
+    " \"outbound_direction_lookup\": \"dst_mac\"\n"
     "}\n";
 
     binary_size = 0;

--- a/misc/tests/utils_unittest.cpp
+++ b/misc/tests/utils_unittest.cpp
@@ -127,9 +127,7 @@ TEST(Utils, CInterface)
     "  \"ipv4\": 16777482\n"
     " },\n"
     " \"vm_vni\": 4321,\n"
-    " \"local_region_id\": 100,\n"
-    " \"trusted_vnis\": [],\n"
-    " \"outbound_direction_lookup\": \"dst_mac\"\n"
+    " \"local_region_id\": 100\n"
     "}\n";
 
     binary_size = 0;

--- a/misc/tests/utils_unittest.cpp
+++ b/misc/tests/utils_unittest.cpp
@@ -128,6 +128,9 @@ TEST(Utils, CInterface)
     " },\n"
     " \"vm_vni\": 4321,\n"
     " \"local_region_id\": 100,\n"
+    " \"trusted_vnis\": {\n"
+    "  \"value\": 100\n"
+    " },\n"
     " \"outbound_direction_lookup\": \"dst_mac\"\n"
     "}\n";
 

--- a/proto/appliance.proto
+++ b/proto/appliance.proto
@@ -4,12 +4,6 @@ package dash.appliance;
 
 import "types.proto";
 
-enum OutboundDirectionLookup {
-    LOOKUP_UNSPECIFIED = 0;
-    LOOKUP_DST_MAC= 1;
-    LOOKUP_SRC_MAC= 2;
-}
-
 message Appliance {
     // source ip address, to be used in encap
     types.IpAddress sip = 1;
@@ -19,7 +13,7 @@ message Appliance {
     uint32 local_region_id = 3;
     // outbound direction lookup. Must be either "dst_mac" or "src_mac"
     optional string outbound_direction_lookup = 4;
-    repeated uint32 trusted_vnis = 5;
+    optional types.ValueOrRange trusted_vnis = 5;
 }
 
 message ApplianceKey {

--- a/proto/eni.proto
+++ b/proto/eni.proto
@@ -41,7 +41,7 @@ message Eni {
     optional string v6_meter_policy_id = 10;
     optional bool disable_fast_path_icmp_flow_redirection = 11;
     optional EniMode eni_mode = 12;
-    repeated uint32 trusted_vnis = 13;
+    optional types.ValueOrRange trusted_vnis = 13;
 }
 
 message EniKey {


### PR DESCRIPTION
- Trusted VNIs are better represented as a single value or a min/max range as per https://github.com/sonic-net/SONiC/pull/1911/files