### PR TITLE
fix(swig): remove explicit libpython linkage from _utils.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ compile_py_proto:
 
 swig: compile_cpp_proto
 	swig -c++ -python -py3 -outdir $(PYPKG_DIR) -o $(BUILD_DIR)/utils_wrap.cpp $(MISC_DIR)/utils.i
-	g++ $(CXX_FLAGS) -shared -I$(PYINCLUDE) -fPIC -I$(MISC_DIR) -o $(PYPKG_DIR)/_utils.so $(MISC_DIR)/utils.cpp $(BUILD_DIR)/utils_wrap.cpp $(wildcard $(BUILD_DIR)/*.pb.cc) $(PYLIBRARY) -lprotobuf
+	g++ $(CXX_FLAGS) -shared -I$(PYINCLUDE) -fPIC -I$(MISC_DIR) -o $(PYPKG_DIR)/_utils.so $(MISC_DIR)/utils.cpp $(BUILD_DIR)/utils_wrap.cpp $(wildcard $(BUILD_DIR)/*.pb.cc) -lprotobuf
 
 clean:
 	$(RM) $(BUILD_DIR)


### PR DESCRIPTION
## Problem
The SWIG extension `_utils.so` was linked with `$(PYLIBRARY)` (e.g. `-lpython3.11`), creating a hard shared library dependency on a specific Python version. Debian's `${shlibs:Depends}` then auto-generated a dependency like `libpython3.11 (>= 3.11.0)`, making the `.deb` uninstallable on systems with a different Python version than the build environment.

## Fix
Removed `$(PYLIBRARY)` from the SWIG link command in the Makefile. On Linux, Python C extensions do not need to link against libpython — the interpreter provides all necessary symbols at runtime.

## Testing
- Built with `make all` — all 5 C++ tests pass
- Verified with `ldd` that `_utils.so` no longer has a libpython dependency